### PR TITLE
Pass args to custom hook

### DIFF
--- a/Jooks.d.ts
+++ b/Jooks.d.ts
@@ -1,7 +1,6 @@
 import React from 'react';
 import 'jest';
-declare type HookFunction<T> = (...args: any[]) => T;
-export declare class Jooks<R> {
+export declare class Jooks<F extends Function> {
     private hookFunction;
     private verbose;
     private stateStore;
@@ -14,7 +13,7 @@ export declare class Jooks<R> {
     private memoStore;
     private reducerStore;
     private cleanupFunctions;
-    constructor(hookFunction: HookFunction<R>, verbose?: boolean);
+    constructor(hookFunction: F, verbose?: boolean);
     /**
      * This should be run before each test.
      * This is automatically called by the init function exposed by the library.
@@ -33,12 +32,12 @@ export declare class Jooks<R> {
      * If they are taking longer, you can increase the wait time to a given time in millisecond.
      * @param wait wait time in millisecond. Defaults to 1.
      */
-    mount(wait?: number): Promise<R>;
+    mount(wait?: number): Promise<void>;
     unmount(wait?: number): Promise<void>;
     /**
      * Executes your hook, and returns the result
      */
-    run(...args: any[]): R;
+    run: F;
     /**
      * Use this to wait for Effects to be executed. Remember to mock all your API calls so that the asyncronous
      * effects are not taking more than 1 event-loop to execute, or more than 1ms.
@@ -69,5 +68,5 @@ export declare class Jooks<R> {
     private fireEffects;
     private fireEffectsCleanup;
 }
-export declare function init<T>(hook: HookFunction<T>, verbose?: boolean): Jooks<T>;
+export declare function init<F extends Function>(hook: F, verbose?: boolean): Jooks<F>;
 export default init;

--- a/Jooks.d.ts
+++ b/Jooks.d.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 import 'jest';
+declare type HookFunction<T> = (...args: any[]) => T;
 export declare class Jooks<R> {
     private hookFunction;
     private verbose;
@@ -13,7 +14,7 @@ export declare class Jooks<R> {
     private memoStore;
     private reducerStore;
     private cleanupFunctions;
-    constructor(hookFunction: () => R, verbose?: boolean);
+    constructor(hookFunction: HookFunction<R>, verbose?: boolean);
     /**
      * This should be run before each test.
      * This is automatically called by the init function exposed by the library.
@@ -37,7 +38,7 @@ export declare class Jooks<R> {
     /**
      * Executes your hook, and returns the result
      */
-    run(): R;
+    run(...args: any[]): R;
     /**
      * Use this to wait for Effects to be executed. Remember to mock all your API calls so that the asyncronous
      * effects are not taking more than 1 event-loop to execute, or more than 1ms.
@@ -68,5 +69,5 @@ export declare class Jooks<R> {
     private fireEffects;
     private fireEffectsCleanup;
 }
-export declare function init<T>(hook: () => T, verbose?: boolean): Jooks<T>;
+export declare function init<T>(hook: HookFunction<T>, verbose?: boolean): Jooks<T>;
 export default init;

--- a/Jooks.js
+++ b/Jooks.js
@@ -147,7 +147,11 @@ var Jooks = /** @class */ (function () {
      * Executes your hook, and returns the result
      */
     Jooks.prototype.run = function () {
-        return this.render();
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+        return this.render.apply(this, args);
     };
     /**
      * Use this to wait for Effects to be executed. Remember to mock all your API calls so that the asyncronous
@@ -397,6 +401,10 @@ var Jooks = /** @class */ (function () {
         return contextValue;
     };
     Jooks.prototype.render = function () {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
         this.stateStore.start();
         this.effectStore.start();
         this.layoutEffectStore.start();
@@ -406,7 +414,7 @@ var Jooks = /** @class */ (function () {
         this.refStore.start();
         this.memoStore.start();
         this.reducerStore.start();
-        return this.hookFunction();
+        return this.hookFunction.apply(this, args);
     };
     Jooks.prototype.fireEffects = function () {
         var _this = this;

--- a/Jooks.js
+++ b/Jooks.js
@@ -54,9 +54,22 @@ var lodash_1 = require("lodash");
 require("jest");
 var Jooks = /** @class */ (function () {
     function Jooks(hookFunction, verbose) {
+        var _this = this;
         if (verbose === void 0) { verbose = false; }
         this.hookFunction = hookFunction;
         this.verbose = verbose;
+        /**
+         * Executes your hook, and returns the result
+         */
+        this.run = (function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            // This weird TypeScript hack ensures that the "run" function has the
+            // exact same signature as your hook.
+            return _this.render.apply(_this, args);
+        });
         this.stateStore = new HookStore('useState');
         this.effectStore = new HookStore('useEffect');
         this.layoutEffectStore = new HookStore('useLayoutEffect');
@@ -123,7 +136,7 @@ var Jooks = /** @class */ (function () {
                         return [4 /*yield*/, this.wait(wait)];
                     case 1:
                         _a.sent();
-                        return [2 /*return*/, this.render()];
+                        return [2 /*return*/];
                 }
             });
         });
@@ -142,16 +155,6 @@ var Jooks = /** @class */ (function () {
                 }
             });
         });
-    };
-    /**
-     * Executes your hook, and returns the result
-     */
-    Jooks.prototype.run = function () {
-        var args = [];
-        for (var _i = 0; _i < arguments.length; _i++) {
-            args[_i] = arguments[_i];
-        }
-        return this.render.apply(this, args);
     };
     /**
      * Use this to wait for Effects to be executed. Remember to mock all your API calls so that the asyncronous

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ The library exposes 3 things:
 - The default export is an initialisation function, as shown in the examples above, hidding the complexity away. This is Jest-specific.
 - `Jooks` class: this is the class that contains the logic and wraps your hook. It is independent from any testing framework so it should be used with other testing frameworks.
 
-### `function init<T>(hook: () => T, verbose?: boolean)` (default export)
+### `function init<T>(hook: (...args: any[]) => T, verbose?: boolean)` (default export)
 
 This function is meant to be called within your test's `describe` function.
 It takes one compulsory argument, and one optional flag:

--- a/README.md
+++ b/README.md
@@ -258,6 +258,45 @@ describe('Testing useContext hook', () => {
 });
 ```
 
+### Custom hooks with arguments
+
+Hooks often rely on passed-in arguments to compute a value, for example:
+
+```javascript
+import { useContext } from 'react';
+import { Context1 } from './ExampleContext';
+
+const useContextWithArgsExample = bar => {
+  const { foo } = useContext(Context1);
+  return foo + ':' + bar;
+};
+
+export default useContextWithArgsExample;
+```
+
+To test these, we can simply pass in the argument when we call `.run()`:
+
+```javascript
+import 'jest';
+import useContextWithArgsExample from '../useContextWithArgsExample';
+import { Context1 } from '../ExampleContext';
+import init from 'jooks';
+
+describe('Testing useContextWithArgsExample hook', () => {
+  const jooks = init(useContextWithArgsExample);
+
+  beforeEach(() => {
+    jooks.setContext(Context1, { foo: 'baz' });
+  });
+
+  it('It should give the correct values', () => {
+    // Here it should compute the hook's return value based on what you passed in
+    const foo = jooks.run('bar');
+    expect(foo).toBe('baz:bar');
+  });
+});
+```
+
 ## API
 
 The library exposes 3 things:

--- a/README.md
+++ b/README.md
@@ -302,24 +302,46 @@ describe('Testing useContextWithArgsExample hook', () => {
 The library exposes 3 things:
 
 - The default export is an initialisation function, as shown in the examples above, hidding the complexity away. This is Jest-specific.
-- `Jooks` class: this is the class that contains the logic and wraps your hook. It is independent from any testing framework so it should be used with other testing frameworks.
+- `Jooks` class: this is the class that contains the logic and wraps your hook. It is independent from any testing framework so it could be used with other testing frameworks.
 
 ### `function init<T>(hook: (...args: any[]) => T, verbose?: boolean)` (default export)
 
 This function is meant to be called within your test's `describe` function.
 It takes one compulsory argument, and one optional flag:
 
-- `hook`: This is a function that calls your hook
+- `hook`: This is a function that calls your hook, or the hook function itself
 - `verbose` (optional): Whether to enable the verbose mode, logging information to the console, for debugging purpose.
 
 ```javascript
-const jooks = init(() => useContextExample());
+const jooks = init(() => useContextExample(someVariable));
+// or
+const jooks = init(useContextExample);
 ```
 
 or, to enable the verbose mode;
 
 ```javascript
 const jooks = init(() => useContextExample(), true);
+// or
+const jooks = init(useContextExample, true);
+```
+
+#### Two ways to initialise Jooks
+
+As see above, you have two ways of initialising a hook :
+
+In the first one, you instantiate your hook on initialisation, with function arguments that are not going to change for the rest of the test:
+
+```javascript
+const jooks = init(() => useContextExample(someVariable));
+jooks.run();
+```
+
+Alternatively, you can specify the Hook function directly, and provide its argument on each `run()` call, like so:
+
+```javascript
+const jooks = init(useContextExample);
+jooks.run(someVariable);
 ```
 
 ### Jooks
@@ -329,7 +351,7 @@ This is the object you get on the third parameter of the describe function.
 It exposes 3 methods that you should care about:
 
 - `async mount(wait: number = 1): Promise<R>`: ensure your hook ran all its effect "on mount"
-- `run()`: this runs your hook function and returns the result. This is usually what you are testing.
+- `run(...hooksParams?)`: this runs your hook function and returns the result. This is usually what you are testing.
 - `async wait(wait: number = 1)`: if you are expecting an asynchronous effect to fire, call this to wait until it's resolved
 
 An additional 2 methods are dedicated to Context:
@@ -342,7 +364,7 @@ There are 2 other public method that you shouldn't use if you are using the init
 - `setup`: this is to be run before every test. This is done automatically if you are using the init function.
 - `cleanup`: this is to be run after every test. This is done automatically if you are using the init function.
 
-#### async mount(wait: number = 1): Promise<R>
+#### async mount(wait: number = 1): Promise<void>
 
 Use this function at the beginning of a test to wait for `useEffect` to fire.
 
@@ -363,7 +385,7 @@ it("Should load activities properly", async () => {
 });
 ```
 
-#### run()
+#### run(...hooksParams?)
 
 This function runs your hook function. Use this to test the hook output.
 
@@ -385,6 +407,10 @@ This is only necessary when your Hook uses `useContext`. You need to call this a
 - Why Jooks? it's a mix of Jest and Hooks.
 - Can I use this? Since it's a testing library (and not a piece of code that's going to production), yes go ahead. The API is likely to change a bit before being stable though, so you might want to pin down your version.
 - There must be a Medium article about that? [Yes, there is.](https://medium.com/@jantoine/another-take-on-testing-custom-react-hooks-4461458935d4)
+
+## Thanks
+
+- Thanks to [@bronter](https://github.com/bronter) for suggesting and implementing the ability to specify a hook function parameters on `run()` instead of just during initialisation.
 
 ## Can I contribute?
 

--- a/src/Jooks.ts
+++ b/src/Jooks.ts
@@ -26,9 +26,7 @@ interface ReducerItem {
   currentState: any;
 }
 
-type HookFunction<T> = (...args: any[]) => T;
-
-export class Jooks<R> {
+export class Jooks<F extends Function> {
   private stateStore: HookStore<any>;
   private effectStore: HookStore<EffectItem>;
   private layoutEffectStore: HookStore<EffectItem>;
@@ -40,7 +38,7 @@ export class Jooks<R> {
   private reducerStore: HookStore<ReducerItem>;
   private cleanupFunctions: Function[];
 
-  constructor(private hookFunction: HookFunction<R>, private verbose: boolean = false) {
+  constructor(private hookFunction: F, private verbose: boolean = false) {
     this.stateStore = new HookStore('useState');
     this.effectStore = new HookStore('useEffect');
     this.layoutEffectStore = new HookStore('useLayoutEffect');
@@ -100,11 +98,10 @@ export class Jooks<R> {
    * If they are taking longer, you can increase the wait time to a given time in millisecond.
    * @param wait wait time in millisecond. Defaults to 1.
    */
-  public async mount(wait: number = 1): Promise<R> {
+  public async mount(wait: number = 1): Promise<void> {
     this.render();
     this.fireEffects();
     await this.wait(wait);
-    return this.render();
   }
 
   public async unmount(wait: number = 1) {
@@ -115,9 +112,11 @@ export class Jooks<R> {
   /**
    * Executes your hook, and returns the result
    */
-  public run(...args: any[]) {
+  public run = (((...args: any[]) => {
+    // This weird TypeScript hack ensures that the "run" function has the
+    // exact same signature as your hook.
     return this.render(...args);
-  }
+  }) as unknown) as F;
 
   /**
    * Use this to wait for Effects to be executed. Remember to mock all your API calls so that the asyncronous
@@ -379,7 +378,7 @@ export class Jooks<R> {
     return contextValue;
   }
 
-  private render(...args: any[]): R {
+  private render(...args: any[]): any {
     this.stateStore.start();
     this.effectStore.start();
     this.layoutEffectStore.start();
@@ -444,7 +443,7 @@ export class Jooks<R> {
   }
 }
 
-export function init<T>(hook: HookFunction<T>, verbose?: boolean) {
+export function init<F extends Function>(hook: F, verbose?: boolean) {
   const mock = new Jooks(hook, verbose);
   beforeEach(() => mock.setup());
   afterEach(() => mock.cleanup());

--- a/src/Jooks.ts
+++ b/src/Jooks.ts
@@ -26,6 +26,8 @@ interface ReducerItem {
   currentState: any;
 }
 
+type HookFunction<T> = (...args: any[]) => T;
+
 export class Jooks<R> {
   private stateStore: HookStore<any>;
   private effectStore: HookStore<EffectItem>;
@@ -38,7 +40,7 @@ export class Jooks<R> {
   private reducerStore: HookStore<ReducerItem>;
   private cleanupFunctions: Function[];
 
-  constructor(private hookFunction: () => R, private verbose: boolean = false) {
+  constructor(private hookFunction: HookFunction<R>, private verbose: boolean = false) {
     this.stateStore = new HookStore('useState');
     this.effectStore = new HookStore('useEffect');
     this.layoutEffectStore = new HookStore('useLayoutEffect');
@@ -113,8 +115,8 @@ export class Jooks<R> {
   /**
    * Executes your hook, and returns the result
    */
-  public run() {
-    return this.render();
+  public run(...args: any[]) {
+    return this.render(...args);
   }
 
   /**
@@ -377,7 +379,7 @@ export class Jooks<R> {
     return contextValue;
   }
 
-  private render(): R {
+  private render(...args: any[]): R {
     this.stateStore.start();
     this.effectStore.start();
     this.layoutEffectStore.start();
@@ -387,7 +389,7 @@ export class Jooks<R> {
     this.refStore.start();
     this.memoStore.start();
     this.reducerStore.start();
-    return this.hookFunction();
+    return this.hookFunction(...args);
   }
 
   private fireEffects() {
@@ -442,7 +444,7 @@ export class Jooks<R> {
   }
 }
 
-export function init<T>(hook: () => T, verbose?: boolean) {
+export function init<T>(hook: HookFunction<T>, verbose?: boolean) {
   const mock = new Jooks(hook, verbose);
   beforeEach(() => mock.setup());
   afterEach(() => mock.cleanup());

--- a/src/__tests__/Jooks.test.ts
+++ b/src/__tests__/Jooks.test.ts
@@ -1,0 +1,10 @@
+import 'jest';
+import init from '../Jooks';
+
+describe('Testing Jooks wrapper', () => {
+  const jooks = init(args => args);
+
+  it('It should pass arguments to hooks', () => {
+    expect(jooks.run('foo')).toEqual('foo');
+  });
+});

--- a/src/__tests__/useMemoExample.test.ts
+++ b/src/__tests__/useMemoExample.test.ts
@@ -9,35 +9,35 @@ const flags = {
 };
 
 describe('Testing useState hook', () => {
-  const jooks = init(() => useMemoExample(spy, flags));
+  const jooks = init(useMemoExample);
   beforeEach(() => {
     spy.mockReset();
   });
 
   it('It should give the correct initial values', () => {
-    const value = jooks.run();
+    const value = jooks.run(spy, flags);
     expect(value).toBe(5);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('It should compute the value only once if nothing else changes', () => {
-    const value = jooks.run();
+    const value = jooks.run(spy, flags);
     expect(value).toBe(5);
-    const value2 = jooks.run(); // Effectively re-running the hook
+    const value2 = jooks.run(spy, flags); // Effectively re-running the hook
     expect(value2).toBe(5);
     // It should have called the memoized function only once, not twice
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it('It should compute the value again if a dependency changes', () => {
-    const value = jooks.run();
+    const value = jooks.run(spy, flags);
     expect(value).toBe(5);
-    const value2 = jooks.run(); // Effectively re-running the hook
+    const value2 = jooks.run(spy, flags); // Effectively re-running the hook
     expect(value2).toBe(5);
     // It should have called the memoized function only once, not twice at this point
     expect(spy).toHaveBeenCalledTimes(1);
     flags.alpha = 3; // Changing the dependency value
-    const value3 = jooks.run(); // Effectively re-running the hook
+    const value3 = jooks.run(spy, flags); // Effectively re-running the hook
     expect(value3).toBe(6);
     // Since the dependency changed, it should have called the memoized function again
     expect(spy).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Suppose I have a custom hook that computes some value based on the result of a context hook, as well as an argument passed into the hook, for example:
```typescript
function useContextPlus(a: number) {
  const b = useContext(numberContext);
  return a + b;
}
```
(React's docs have a more practical example here: https://reactjs.org/docs/hooks-custom.html#extracting-a-custom-hook)

Currently, testing this requires hard-coding the values during `init`, which means testing different values requires calling `init` for each value:
```typescript
describe('0', () => {
  // Get an invariant violation if I try to use `init` inside the same scope as `setContext`/`run`
  const jooks = init(() => useContextPlus(0));
  it('can add 0 to the context value', () => {
    jooks.setContext(numberContext, 0);
    expect(jooks.run()).toBe(0);
  });
});
// Also get an invariant violation if I try to use more than one `init` in the same scope
describe('1', () => {
  const jooks = init(() => useContextPlus(1));
  it('can add 1 to the context value', () => {
    jooks.setContext(numberContext, 0);
    expect(jooks.run()).toBe(1);
  });
});
```

If we could pass parameters into `run`, we could instead do:
```typescript
const jooks = init(useContextPlus);
beforeEach(() => jooks.setContext(numberContext, 0));
it('can add 0 to the context value', () => {
  expect(jooks.run(0)).toBe(0);
}
it('can add 1 to the context value', () => {
  expect(jooks.run(1)).toBe(1);
}
```

This PR enables that.